### PR TITLE
Attach files to Lumen notice

### DIFF
--- a/server/src/Client/LumenClient.php
+++ b/server/src/Client/LumenClient.php
@@ -88,7 +88,7 @@ class LumenClient implements LumenClientInterface {
 
 			$files = [];
 
-			$takedown->getDmca()->getFiles()->forAll( function ( $index, $file ) {
+			$takedown->getDmca()->getFiles()->forAll( function ( $index, $file ) use ( &$files ) {
 				$files[] = [
 					'name' => 'notice[file_uploads_attributes][' . $index . '][file]',
 					'filename' => $file->getName(),

--- a/server/src/Util/TakedownUtil.php
+++ b/server/src/Util/TakedownUtil.php
@@ -85,6 +85,9 @@ class TakedownUtil implements TakedownUtilInterface {
 	public function create( Takedown $takedown ) : PromiseInterface {
 		$promises = [];
 
+		// Attach the takedown to existing entities.
+		$takedown = $this->attacher->attach( $takedown );
+
 		if ( $takedown->getReporter() ) {
 			// If the reporter is the same as the current user, set the current user
 			// object as the report since it has more data.
@@ -143,9 +146,6 @@ class TakedownUtil implements TakedownUtilInterface {
 		// in an event loop.
 		return \GuzzleHttp\Promise\all( $promises )->then( function () use ( $takedown ) {
 			$em = $this->doctrine->getEntityManager();
-
-			// Attach the takedown to existing entities.
-			$takedown = $this->attacher->attach( $takedown );
 
 			// Remove the related entities.
 			// @link https://github.com/doctrine/doctrine2/issues/6531


### PR DESCRIPTION
The scoping of the `forAll()` closure prevented anything from being added to the
`$files` array.

Likewise, the existing entities not being attached meant that all properties
of a `File` were `null` which resulted in empty files being sent.

Bug: [T250507](https://phabricator.wikimedia.org/T250507)